### PR TITLE
Improve landing page meta information and tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Christian Mkhitaryan - Fachanwalt für Migrationsrecht | Aschaffenburg</title>
   <meta name="description"
+    data-de="Christian Mkhitaryan - Fachanwalt für Migrationsrecht in Aschaffenburg. Spezialist für Aufenthaltsrecht, Staatsangehörigkeitsrecht und Familienzusammenführung."
+    data-en="Christian Mkhitaryan - Specialist lawyer for migration law in Aschaffenburg. Expert in residence law, citizenship law and family reunification."
     content="Christian Mkhitaryan - Fachanwalt für Migrationsrecht in Aschaffenburg. Spezialist für Aufenthaltsrecht, Staatsangehörigkeitsrecht und Familienzusammenführung.">
+  <link rel="icon" type="image/png" href="assets/logo.png">
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -112,6 +115,7 @@
               Christian<br>
               <span class="bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">Mkhitaryan</span>
             </h1>
+            <p class="text-2xl text-gray-700 mb-4">Ihr Weg nach Deutschland beginnt hier</p>
             <p class="text-xl text-gray-600 mb-8 max-w-2xl leading-relaxed">
               Ihr Spezialist für deutsches Migrationsrecht in Aschaffenburg. Mit langjähriger Erfahrung begleite ich Sie
               kompetent durch alle Verfahren – von der Visa-Beantragung bis zur Einbürgerung.
@@ -137,6 +141,7 @@
               Christian<br>
               <span class="bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">Mkhitaryan</span>
             </h1>
+            <p class="text-2xl text-gray-700 mb-4">Your path to Germany starts here</p>
             <p class="text-xl text-gray-600 mb-8 max-w-2xl leading-relaxed">
               Your specialist for German migration law in Aschaffenburg. With years of experience, I guide you
               competently through all procedures – from visa applications to naturalization.

--- a/main.js
+++ b/main.js
@@ -88,10 +88,19 @@ function setupLanguageToggle() {
     localStorage.setItem('lang', lang);
     
     // Update page title
-    const title = lang === 'de' 
+    const title = lang === 'de'
       ? 'Christian Mkhitaryan - Fachanwalt für Migrationsrecht | Aschaffenburg'
       : 'Christian Mkhitaryan - Specialist Lawyer for Migration Law | Aschaffenburg';
     document.title = title;
+
+    // Update meta description
+    const descriptionMeta = document.querySelector('meta[name="description"]');
+    if (descriptionMeta) {
+      const description = lang === 'de'
+        ? descriptionMeta.dataset.de
+        : descriptionMeta.dataset.en;
+      descriptionMeta.setAttribute('content', description);
+    }
   }
 
   if (langToggle) {


### PR DESCRIPTION
## Summary
- add localized meta description and favicon for branding
- enhance hero section with bilingual tagline
- update language toggle script to switch meta description

## Testing
- `node --check main.js`
- `npx -y htmlhint index.html` *(fails: 403 Forbidden - registry access)*

------
https://chatgpt.com/codex/tasks/task_e_6898615b51c4832f8e3423a361bf5200